### PR TITLE
Add method to remove stale triggers

### DIFF
--- a/lib/pg_audit_log/triggers.rb
+++ b/lib/pg_audit_log/triggers.rb
@@ -40,9 +40,11 @@ module PgAuditLog
         tables.each do |table|
           create_for_table(table) unless tables_with_triggers.include?(table)
         end
+      end
 
-        extra_tables = tables_with_triggers - tables
-        extra_tables.each do |table|
+      def uninstall_extra
+        tables_with_extra_triggers = tables_with_triggers - tables
+        tables_with_extra_triggers.each do |table|
           drop_for_table(table)
         end
       end

--- a/lib/pg_audit_log/triggers.rb
+++ b/lib/pg_audit_log/triggers.rb
@@ -40,6 +40,11 @@ module PgAuditLog
         tables.each do |table|
           create_for_table(table) unless tables_with_triggers.include?(table)
         end
+
+        extra_tables = tables_with_triggers - tables
+        extra_tables.each do |table|
+          drop_for_table(table)
+        end
       end
 
       def uninstall

--- a/lib/pg_audit_log/triggers.rb
+++ b/lib/pg_audit_log/triggers.rb
@@ -42,9 +42,9 @@ module PgAuditLog
         end
       end
 
-      def uninstall_extra
-        tables_with_extra_triggers = tables_with_triggers - tables
-        tables_with_extra_triggers.each do |table|
+      def uninstall_stale
+        tables_with_stale_triggers = tables_with_triggers - tables
+        tables_with_stale_triggers.each do |table|
           drop_for_table(table)
         end
       end

--- a/spec/triggers_spec.rb
+++ b/spec/triggers_spec.rb
@@ -70,10 +70,10 @@ describe PgAuditLog::Triggers do
       end
     end
 
-    describe ".uninstall_extra" do
+    describe ".uninstall_stale" do
       it 'should work' do
         expect {
-          PgAuditLog::Triggers.uninstall_extra
+          PgAuditLog::Triggers.uninstall_stale
         }.not_to raise_error
       end
     end
@@ -96,10 +96,10 @@ describe PgAuditLog::Triggers do
       end
     end
 
-    describe ".uninstall_extra" do
+    describe ".uninstall_stale" do
       it 'should work' do
         expect {
-          PgAuditLog::Triggers.uninstall_extra
+          PgAuditLog::Triggers.uninstall_stale
         }.not_to raise_error
       end
     end

--- a/spec/triggers_spec.rb
+++ b/spec/triggers_spec.rb
@@ -70,6 +70,13 @@ describe PgAuditLog::Triggers do
       end
     end
 
+    describe ".uninstall_extra" do
+      it 'should work' do
+        expect {
+          PgAuditLog::Triggers.uninstall_extra
+        }.not_to raise_error
+      end
+    end
   end
 
   context "when triggers are installed" do
@@ -80,10 +87,19 @@ describe PgAuditLog::Triggers do
         }.not_to raise_error
       end
     end
+
     describe ".uninstall" do
       it "should work" do
         expect{
           PgAuditLog::Triggers.uninstall
+        }.not_to raise_error
+      end
+    end
+
+    describe ".uninstall_extra" do
+      it 'should work' do
+        expect {
+          PgAuditLog::Triggers.uninstall_extra
         }.not_to raise_error
       end
     end


### PR DESCRIPTION
Adds a method to PgAuditLog::Trigger that makes it possible for a caller to remove triggers that were previously installed, but are no longer needed. I tested this locally and confirmed that it works as expected. The specs for this code are not the best, but I just kind of imitated them and decided not to worry about it too much.