### PR TITLE
[FCM-DebtDay] Fix keyword args deprecations in exec_query method

### DIFF
--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -40,19 +40,19 @@ module PGAuditExtensions
     super(sql, name = nil)
   end
 
-  def exec_query(*args, &block)
+  def exec_query(*args, **kwargs, &block)
     set_audit_user_id_and_name
-    super(*args, &block)
+    super(*args, **kwargs, &block)
   end
 
-  def exec_update(*args, &block)
+  def exec_update(*args, **kwargs, &block)
     set_audit_user_id_and_name
-    super(*args, &block)
+    super(*args, **kwargs, &block)
   end
 
-  def exec_delete(*args, &block)
+  def exec_delete(*args, **kwargs, &block)
     set_audit_user_id_and_name
-    super(*args, &block)
+    super(*args, **kwargs, &block)
   end
 end
 

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -45,14 +45,14 @@ module PGAuditExtensions
     super(*args, **kwargs, &block)
   end
 
-  def exec_update(*args, **kwargs, &block)
+  def exec_update(*args, &block)
     set_audit_user_id_and_name
-    super(*args, **kwargs, &block)
+    super(*args, &block)
   end
 
-  def exec_delete(*args, **kwargs, &block)
+  def exec_delete(*args, &block)
     set_audit_user_id_and_name
-    super(*args, **kwargs, &block)
+    super(*args, &block)
   end
 end
 

--- a/spec/pg_audit_log_spec.rb
+++ b/spec/pg_audit_log_spec.rb
@@ -165,7 +165,7 @@ describe PgAuditLog do
         end
 
         context "when going from a value to a another value" do
-          before { @model.update_attributes!(:str => 'bar') }
+          before { @model.update!(:str => 'bar') }
           subject { PgAuditLog::Entry.where(:field_name => 'str').last }
 
           describe '#operation' do
@@ -186,7 +186,7 @@ describe PgAuditLog do
 
         context "when going from nil to a value" do
           let(:attributes) { {:txt => nil} }
-          before { @model.update_attributes!(:txt => 'baz') }
+          before { @model.update!(:txt => 'baz') }
           subject { PgAuditLog::Entry.where(:field_name => 'txt').last }
 
           describe '#field_value_new' do
@@ -201,7 +201,7 @@ describe PgAuditLog do
         end
 
         context "when going from a value to nil" do
-          before { @model.update_attributes!(:str => nil) }
+          before { @model.update!(:str => nil) }
           subject { PgAuditLog::Entry.where(:field_name => 'str').last }
 
           describe '#field_value_new' do
@@ -216,7 +216,7 @@ describe PgAuditLog do
         end
 
         context "when the value does not change" do
-          before { @model.update_attributes!(:str => 'foo') }
+          before { @model.update!(:str => 'foo') }
           subject { PgAuditLog::Entry.where(:field_name => 'str', :operation => 'UPDATE').last }
 
           it { is_expected.not_to be }
@@ -224,7 +224,7 @@ describe PgAuditLog do
 
         context "when the value is nil and does not change" do
           let(:attributes) { {:txt => nil} }
-          before { @model.update_attributes!(:txt => nil) }
+          before { @model.update!(:txt => nil) }
           subject { PgAuditLog::Entry.where(:field_name => 'txt', :operation => 'UPDATE').last }
 
           it { is_expected.not_to be }
@@ -232,7 +232,7 @@ describe PgAuditLog do
 
         context "when the value is a boolean" do
           context "going from nil -> true" do
-            before { @model.update_attributes!(:bool => true) }
+            before { @model.update!(:bool => true) }
             subject { PgAuditLog::Entry.where(:field_name => 'bool', :operation => 'UPDATE').last }
 
             describe '#field_value_new' do
@@ -249,7 +249,7 @@ describe PgAuditLog do
           context "going from false -> true" do
             let(:attributes) { {:bool => false} }
             before do
-              @model.update_attributes!(:bool => true)
+              @model.update!(:bool => true)
             end
             subject { PgAuditLog::Entry.where(:field_name => 'bool', :operation => 'UPDATE').last }
 
@@ -268,7 +268,7 @@ describe PgAuditLog do
             let(:attributes) { {:bool => true} }
 
             before do
-              @model.update_attributes!(:bool => false)
+              @model.update!(:bool => false)
             end
             subject { PgAuditLog::Entry.where(:field_name => 'bool', :operation => 'UPDATE').last }
 


### PR DESCRIPTION
The method signature of the `exec_query` method that `pg_audit_log` is monkey patching has keyword args in its signature: https://github.com/rails/rails/blob/914caca2d31bd753f47f9168f2a375921d9e91cc/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L52

Our fix here is to update the method signature of the `exec_query` method to also accept keyword args so that they're correctly forwarded when `super` is called.

We also updated the specs to use the `update!` method instead of `update_attributes!` so that they'd pass.

## Testing

We pulled in this branch on another branch of the fcm app and saw that tests still pass in CI with this change: https://app.circleci.com/pipelines/github/footholdtech/rma/14633/workflows/55a1ad29-b79c-4d96-8a12-86a226990416

## Deployment

After this is merged, we'll update the Gemfile.lock in the fcm app to use the new version of our pg_audit_log fork.