### PR TITLE
Fix kwargs in create_table and drop_table methods

### DIFF
--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -1,15 +1,15 @@
 require 'active_record/connection_adapters/postgresql_adapter'
 
 module PGAuditExtensions
-  def drop_table(table_name)
+  def drop_table(table_name, **options)
     if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
       PgAuditLog::Triggers.drop_for_table(table_name)
     end
-    super(table_name)
+    super(table_name, **options)
   end
 
-  def create_table(table_name, options = {}, &block)
-    super(table_name, options, &block)
+  def create_table(table_name, **options, &block)
+    super(table_name, **options, &block)
     unless options[:temporary] ||
       PgAuditLog::IGNORED_TABLES.include?(table_name) ||
       PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||


### PR DESCRIPTION
## Overview

Similar to https://github.com/footholdtech/pg_audit_log/pull/6. This kwargs warning wasn't spotted by our test suite, but comes up when running a migration with a `create_table` method call:

```
-- create_table(:strengths)
/Users/ihollander/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/bundler/gems/pg_audit_log-8db3ca91a578/lib/pg_audit_log/extensions/postgresql_adapter.rb:12: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/ihollander/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activerecord-6.1.7.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:296: warning: The called method `create_table' is defined here
```

The method signature of the [`create_table`](https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_table) method that `pg_audit_log` is monkey patching has keyword args in its signature: https://github.com/rails/rails/blob/v6.1.7.2/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L296

Additionally, [`drop_table`](https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_table) also takes options, which `pg_audit_log` wasn't handling at all: https://github.com/rails/rails/blob/v6.1.7.2/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L514

Since `create_table` method calls `drop_table` when rolling back a migration via a `change` method, passing options like this:

```rb
def change
  create_table :migration_tests, id: false do |t|
    t.timestamps
  end
end
```

...isn't working at all and would result in an error:

```
-- drop_table(:migration_tests, {:id=>false})
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

unknown keyword: :id
```

Updating the method signature of these patched methods to use kwargs fixes both these issues.

## Testing

I temporarily pointed to this branch in the Gemfile of the rma codebase ran a migration with the above create_table call, and saw that the kwargs warning was no longer present, and that the options worked as expected (in this case, creating a table without an ID column). I also was able to roll back the migration successfully, confirming the `drop_table` method works with the additional options.

## Deployment

After this is merged, we'll update the Gemfile.lock in the rma codebase to use the new version of our pg_audit_log fork.